### PR TITLE
Fixing Javascript to be compatible with jquery3

### DIFF
--- a/app/assets/javascripts/will_paginate_infinite.js
+++ b/app/assets/javascripts/will_paginate_infinite.js
@@ -1,11 +1,11 @@
 jQuery(function() {
-  if ($('.infinite-pagination').size() > 0) {
+  if ($('.infinite-pagination').length > 0) {
     $(window).on('scroll', function() {
       var more_posts_url = $('.infinite-pagination a.next_page').attr('href');
       var bottom_distance = 20;
 
       if (more_posts_url && $(window).scrollTop() > $(document).height() - $(window).height() - bottom_distance) {
-        $('.infinite-pagination').html('Carregando...');
+        $('.infinite-pagination').html('<div class="infinite-loading">Loading...</div>');
         $.getScript(more_posts_url);
       }
     });

--- a/app/assets/stylesheets/will_paginate_infinite.scss
+++ b/app/assets/stylesheets/will_paginate_infinite.scss
@@ -1,0 +1,8 @@
+.infinite-loading {
+  font-size: 1.5rem;
+  font-weight: 300;
+  line-height: 1.2;
+  color: #6c757d;
+  text-align: center;
+  padding: 1.5rem 0;
+}

--- a/will_paginate_infinite.gemspec
+++ b/will_paginate_infinite.gemspec
@@ -3,8 +3,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'version'
 Gem::Specification.new do |s|
   s.name        = 'will_paginate_infinite'
-  s.version     = '0.1.3'
-  s.date        = '2016-07-29'
+  s.version     = '0.1.4'
+  s.date        = '2018-09-21'
   s.summary     = "Will Paginate with infinite scroll"
   s.description = "Will Paginate with infinite scroll"
   s.authors     = ["Adriano Godoy"]
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.rdoc_options = ['--main', 'README.md', '--charset=UTF-8']
   s.extra_rdoc_files = ['README.md']
-  
+
   s.add_runtime_dependency "will_paginate", '~> 3.0', '>= 3.0.3'
 end


### PR DESCRIPTION
## Change log:

- [x] I replaced the `size()` with length since size is already deprecated.
- [x] I upgraded the version so you can push it.