### PR TITLE
Only remove proper scroll event handler.

### DIFF
--- a/app/assets/javascripts/will_paginate_infinite.js
+++ b/app/assets/javascripts/will_paginate_infinite.js
@@ -1,13 +1,15 @@
+function infinitePaginationFunction() {
+  var more_posts_url = $('.infinite-pagination a.next_page').attr('href');
+  var bottom_distance = 20;
+
+  if (more_posts_url && $(window).scrollTop() > $(document).height() - $(window).height() - bottom_distance) {
+    $('.infinite-pagination').html('<div class="infinite-loading">Loading...</div>');
+    $.getScript(more_posts_url);
+  }
+}
+
 jQuery(function() {
   if ($('.infinite-pagination').length > 0) {
-    $(window).on('scroll', function() {
-      var more_posts_url = $('.infinite-pagination a.next_page').attr('href');
-      var bottom_distance = 20;
-
-      if (more_posts_url && $(window).scrollTop() > $(document).height() - $(window).height() - bottom_distance) {
-        $('.infinite-pagination').html('<div class="infinite-loading">Loading...</div>');
-        $.getScript(more_posts_url);
-      }
-    });
+    $(window).on('scroll', infinitePaginationFunction);
   }
 });

--- a/app/helpers/infinite_helper.rb
+++ b/app/helpers/infinite_helper.rb
@@ -8,7 +8,7 @@ module InfiniteHelper
     if collection.next_page
       html += "$('.infinite-pagination').replaceWith('" + j(will_paginate(collection, renderer: WillPaginateInfinite::InfinitePagination)) + "');"
     else
-      html += "$(window).off('scroll');"
+      html += "$(window).off('scroll', infinitePaginationFunction);"
       html += "$('.infinite-pagination').remove();"
     end
 


### PR DESCRIPTION
When working with a plugin and adding/removing events, it's advised to remove only the events that you've added, to avoid breaking things outside the plugin scope.